### PR TITLE
Add error handling to mongoDB ObjectId method to prevent hanging conn…

### DIFF
--- a/server/mongo-query.js
+++ b/server/mongo-query.js
@@ -44,7 +44,13 @@ async function find(collectionName, idString) {
   const collection = db.collection(collectionName);
 
   // Convert the string ID to ObjectId
-  const objectId = new ObjectId(idString);
+  let objectId
+  try {
+    objectId = new ObjectId(idString);
+  } catch (error) {
+    closeDatabaseConnection();
+    return null;
+  }
 
   const result = await collection.findOne(objectId);
   closeDatabaseConnection();
@@ -58,7 +64,13 @@ async function remove(collectionName, idString) {
   const collection = db.collection(collectionName);
 
   // Convert the string ID to ObjectId
-  const objectId = new ObjectId(idString);
+  let objectId
+  try {
+    objectId = new ObjectId(idString);
+  } catch (error) {
+    closeDatabaseConnection();
+    return null;
+  }
 
   //Delete the record with the given id
   const result = await collection.deleteOne({_id: objectId});
@@ -72,9 +84,6 @@ async function removeAll(collectionName, binId) {
   const db = await connectToDatabase();
   //Get the collection
   const collection = db.collection(collectionName);
-
-  // Convert the string ID to ObjectId
-  // const objectId = new ObjectId(bin_id);
 
   //Delete the record with the given id
   const result = await collection.deleteMany({ bin_id: binId });


### PR DESCRIPTION
This fixes a bug where if you tried to get or remove a mongoDB document and the key you passed to the api wasn't eligible to be converted to a mongoDB id key by `new ObjectId(id)` method the api would hang. 

The `ObjectId()` method throws this error: `BSONError('input must be a 24 character hex string, 12 byte Uint8Array, or an integer')` in those cases. However that error wasn't being escalated to a point we could see or handle it, instead it would just silently fail and the connection would hang. These changes fix that and just close the connection and return null in those cases.